### PR TITLE
Change to fix 'null' in subtitle label when episode was set but publish date was not. 

### DIFF
--- a/Zype/Utilities/UIUtil.m
+++ b/Zype/Utilities/UIUtil.m
@@ -234,9 +234,10 @@
       if (stringPublished.length > 0)
           result = [NSString stringWithFormat:@"%@", stringPublished];
     }
-    else
+    else if (stringPublished.length > 0)
         result = [NSString stringWithFormat:@"%@ | %@", stringPublished, stringEpisode];
-    
+    else
+        result = [NSString stringWithFormat:@"%@", stringEpisode];
     return result;
 }
 


### PR DESCRIPTION
Add validation to check if the episode number is set in the metadata but the publish date is not. 

![null](https://user-images.githubusercontent.com/50967917/61741730-e6fba900-ad67-11e9-8df6-e76f0932c943.jpeg)

After the change: 
![Screen Shot 2019-07-23 at 16 36 55](https://user-images.githubusercontent.com/50967917/61741884-3cd05100-ad68-11e9-9b1a-2f57c5e33335.png)



