### PR TITLE
Fix for crash issue caused by accessing UIKit from BG threads in subscription flow

### DIFF
--- a/Zype/Managers/ACPurchaseManager.m
+++ b/Zype/Managers/ACPurchaseManager.m
@@ -59,13 +59,17 @@
 
 - (void)requestSubscriptions:(void(^)(NSArray *))success failure:(void(^)(NSString *))failure {
     [[RMStore defaultStore] requestProducts:self.subscriptions success:^(NSArray *products, NSArray *invalidProductIdentifiers) {
-        if (products != nil) {
-            success(products);
-        } else {
-            failure(@"Not products");
-        }
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (products != nil) {
+                success(products);
+            } else {
+                failure(@"Not products");
+            }
+        });
     } failure:^(NSError *error) {
-        failure(error.localizedDescription);
+        dispatch_async(dispatch_get_main_queue(), ^{
+            failure(error.localizedDescription);
+        });
     }];
 }
 


### PR DESCRIPTION
Details of the crash issue is mentioned at JIRA https://zypeinc.atlassian.net/browse/APPS-730

Reason - UiKit API's (UITableView reloadData) was accessed inside background threads while requesting products in subscription flow.

Stack trace of crash - 

2020-02-21 09:51:00.474593-0500 Zype TV[47514:1995822] +[ACSTokenManager saveLoginAccessTokenData:block:]_block_invoke_3 line 80 $ Consumer ID Check: 5e4fe5e5ba91ea00011508bb
2020-02-21 09:51:01.580472-0500 Zype TV[47514:1998518] RMStore: products request received response
2020-02-21 09:51:01.581023-0500 Zype TV[47514:1998518] RMStore: invalid product with id yearlysubscriptionro
2020-02-21 09:51:01.581607-0500 Zype TV[47514:1998518] RMStore: invalid product with id monthlyraisedoutdoors

**Main Thread Checker: UI API called on a background thread: -[UITableView reloadData]**
PID: 47514, TID: 1998518, Thread name: (none), Queue name: com.apple.root.default-qos, QoS: 0
Backtrace:
4   Zype TV                             0x00000001075a99cd __44-[SubsciptionViewController requestProducts]_block_invoke_2 + 157
5   Zype TV                             0x0000000107626eab __50-[ACPurchaseManager requestSubscriptions:failure:]_block_invoke + 107
6   Zype TV                             0x00000001077b6821 -[RMProductsRequestDelegate productsRequest:didReceiveResponse:] + 1201
7   StoreKit                            0x00007fff2bf588c2 __27-[SKProductsRequest _start]_block_invoke_2 + 206
8   libdispatch.dylib                   0x0000000108a8fdd4 _dispatch_call_block_and_release + 12
9   libdispatch.dylib                   0x0000000108a90d48 _dispatch_client_callout + 8
10  libdispatch.dylib                   0x0000000108a931ef _dispatch_queue_override_invoke + 1022
11  libdispatch.dylib                   0x0000000108aa228c _dispatch_root_queue_drain + 351
12  libdispatch.dylib                   0x0000000108aa2b96 _dispatch_worker_thread2 + 132
13  libsystem_pthread.dylib             0x00007fff524636b6 _pthread_wqthread + 220
14  libsystem_pthread.dylib             0x00007fff52462827 start_wqthread + 15
