### PR TITLE
Arrow Image, Now text and Summary tab color/brand fixes

### DIFF
--- a/Zype/Utilities/ZypeCommon.h
+++ b/Zype/Utilities/ZypeCommon.h
@@ -85,7 +85,7 @@
 // Enable to show Publish At Date
 #define kShowPublishedAtDate YES
 
-#define kClientColor    [UIUtil colorWithHex:0xF75532];
+#define kClientColor    [UIUtil colorWithHex:0xF75532]
 #define kTextPlaceholderColor [UIColor colorWithRed:0.72 green:0.72 blue:0.75 alpha:1.00]
 #define kLightTintColor [UIColor colorWithRed:1.00 green:0.11 blue:0.38 alpha:1.00]
 #define kLightLineColor [UIColor colorWithRed:0.70 green:0.70 blue:0.70 alpha:1.00]

--- a/Zype/ViewController/ForgotPasswordViewController.m
+++ b/Zype/ViewController/ForgotPasswordViewController.m
@@ -63,9 +63,9 @@
     [self.btnSignup setAttributedTitle:attrstringFirstPart forState:UIControlStateNormal];
     
     NSString *arrowImageString = (kAppColorLight) ? @"arrow-light" : @"arrow-black";
-    [self.arrowImageView setImage:[UIImage imageNamed:arrowImageString]];
-    [self.arrowImageView setTintColor: signUpColor];
-    
+    [self.arrowImageView setImage:[[UIImage imageNamed:arrowImageString] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate]];
+    self.arrowImageView.tintColor = kCurrentAppColor;
+
     UITapGestureRecognizer * tapRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(viewTapped:)];
     [self.view addGestureRecognizer:tapRecognizer];
     

--- a/Zype/ViewController/ForgotPasswordViewController.m
+++ b/Zype/ViewController/ForgotPasswordViewController.m
@@ -64,7 +64,7 @@
     
     NSString *arrowImageString = (kAppColorLight) ? @"arrow-light" : @"arrow-black";
     [self.arrowImageView setImage:[[UIImage imageNamed:arrowImageString] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate]];
-    self.arrowImageView.tintColor = kCurrentAppColor;
+    self.arrowImageView.tintColor = kClientColor;
 
     UITapGestureRecognizer * tapRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(viewTapped:)];
     [self.view addGestureRecognizer:tapRecognizer];

--- a/Zype/ViewController/IntroViewController.m
+++ b/Zype/ViewController/IntroViewController.m
@@ -47,7 +47,7 @@
     [self.loginButton setTitleColor:textColor forState:UIControlStateNormal];
     
     NSString *appName = [[[NSBundle mainBundle] infoDictionary] objectForKey:(NSString*)kCFBundleNameKey];
-    self.titleLabel.text = [NSString stringWithFormat:@"%@ Now", appName];
+    self.titleLabel.text = [NSString stringWithFormat:@"%@", appName];
 }
 
 - (void)viewWillAppear:(BOOL)animated {

--- a/Zype/ViewController/RegisterViewController.m
+++ b/Zype/ViewController/RegisterViewController.m
@@ -90,8 +90,9 @@
     [self.signinButton setAttributedTitle:attrstringFirstPart forState:UIControlStateNormal];
     
     NSString *arrowImageString = (kAppColorLight) ? @"arrow-light" : @"arrow-black";
-    [self.arrowImageView setImage:[UIImage imageNamed:arrowImageString]];
-    
+    [self.arrowImageView setImage:[[UIImage imageNamed:arrowImageString] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate]];
+    self.arrowImageView.tintColor = kCurrentAppColor;
+
     UITapGestureRecognizer * tapRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(viewTapped:)];
     [self.view addGestureRecognizer:tapRecognizer];
 }

--- a/Zype/ViewController/RegisterViewController.m
+++ b/Zype/ViewController/RegisterViewController.m
@@ -91,7 +91,7 @@
     
     NSString *arrowImageString = (kAppColorLight) ? @"arrow-light" : @"arrow-black";
     [self.arrowImageView setImage:[[UIImage imageNamed:arrowImageString] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate]];
-    self.arrowImageView.tintColor = kCurrentAppColor;
+    self.arrowImageView.tintColor = kClientColor;
 
     UITapGestureRecognizer * tapRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(viewTapped:)];
     [self.view addGestureRecognizer:tapRecognizer];

--- a/Zype/ViewController/SignInViewController.m
+++ b/Zype/ViewController/SignInViewController.m
@@ -150,7 +150,7 @@
     
     NSString *arrowImageString = (kAppColorLight) ? @"arrow-light" : @"arrow-black";
     [self.arrowImageView setImage:[[UIImage imageNamed:arrowImageString] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate]];
-    self.arrowImageView.tintColor = kCurrentAppColor;
+    self.arrowImageView.tintColor = kClientColor;
 
     // Dismiss keyboard
     UITapGestureRecognizer *tapRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(dismissKeyboard:)];

--- a/Zype/ViewController/SignInViewController.m
+++ b/Zype/ViewController/SignInViewController.m
@@ -149,7 +149,9 @@
     [self.signupButton setAttributedTitle:attrstring forState:UIControlStateNormal];
     
     NSString *arrowImageString = (kAppColorLight) ? @"arrow-light" : @"arrow-black";
-    [self.arrowImageView setImage:[UIImage imageNamed:arrowImageString]];
+    [self.arrowImageView setImage:[[UIImage imageNamed:arrowImageString] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate]];
+    self.arrowImageView.tintColor = kCurrentAppColor;
+
     // Dismiss keyboard
     UITapGestureRecognizer *tapRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(dismissKeyboard:)];
     tapRecognizer.cancelsTouchesInView = YES;

--- a/Zype/ViewController/VideoDetailViewController.m
+++ b/Zype/ViewController/VideoDetailViewController.m
@@ -482,7 +482,15 @@ static NSString *kOptionTableViewCell = @"OptionTableViewCell";
 }
 
 - (void)configureColors{
-    self.segmenedControl.tintColor = kClientColor;
+    if (@available(iOS 13.0, *)) {
+        self.segmenedControl.selectedSegmentTintColor = kCurrentAppColor;
+    } else {
+        // Fallback on earlier versions
+        self.segmenedControl.tintColor = kCurrentAppColor;
+    }
+    
+    [[UISegmentedControl appearance] setTitleTextAttributes:@{NSForegroundColorAttributeName : kCurrentAppColor} forState:UIControlStateNormal];
+    [[UISegmentedControl appearance] setTitleTextAttributes:@{NSForegroundColorAttributeName : [UIColor blackColor]} forState:UIControlStateSelected];
 }
 
 - (void)setDetailItem:(id)newDetailItem {

--- a/Zype/ViewController/VideoDetailViewController.m
+++ b/Zype/ViewController/VideoDetailViewController.m
@@ -483,13 +483,13 @@ static NSString *kOptionTableViewCell = @"OptionTableViewCell";
 
 - (void)configureColors{
     if (@available(iOS 13.0, *)) {
-        self.segmenedControl.selectedSegmentTintColor = kCurrentAppColor;
+        self.segmenedControl.selectedSegmentTintColor = kClientColor;
     } else {
         // Fallback on earlier versions
-        self.segmenedControl.tintColor = kCurrentAppColor;
+        self.segmenedControl.tintColor = kClientColor;
     }
     
-    [[UISegmentedControl appearance] setTitleTextAttributes:@{NSForegroundColorAttributeName : kCurrentAppColor} forState:UIControlStateNormal];
+    [[UISegmentedControl appearance] setTitleTextAttributes:@{NSForegroundColorAttributeName : kClientColor} forState:UIControlStateNormal];
     [[UISegmentedControl appearance] setTitleTextAttributes:@{NSForegroundColorAttributeName : [UIColor blackColor]} forState:UIControlStateSelected];
 }
 

--- a/Zype/ViewController/WatcherSignInViewController.m
+++ b/Zype/ViewController/WatcherSignInViewController.m
@@ -148,7 +148,9 @@
     [self.signupButton setAttributedTitle:attrstring forState:UIControlStateNormal];
     
     NSString *arrowImageString = (kAppColorLight) ? @"arrow-light" : @"arrow-black";
-    [self.arrowImageView setImage:[UIImage imageNamed:arrowImageString]];
+    [self.arrowImageView setImage:[[UIImage imageNamed:arrowImageString] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate]];
+    self.arrowImageView.tintColor = kCurrentAppColor;
+     
     // Dismiss keyboard
     UITapGestureRecognizer *tapRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(dismissKeyboard:)];
     tapRecognizer.cancelsTouchesInView = YES;

--- a/Zype/ViewController/WatcherSignInViewController.m
+++ b/Zype/ViewController/WatcherSignInViewController.m
@@ -149,7 +149,7 @@
     
     NSString *arrowImageString = (kAppColorLight) ? @"arrow-light" : @"arrow-black";
     [self.arrowImageView setImage:[[UIImage imageNamed:arrowImageString] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate]];
-    self.arrowImageView.tintColor = kCurrentAppColor;
+    self.arrowImageView.tintColor = kClientColor;
      
     // Dismiss keyboard
     UITapGestureRecognizer *tapRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(dismissKeyboard:)];

--- a/Zype/ViewController/WatcherSignUpViewController.m
+++ b/Zype/ViewController/WatcherSignUpViewController.m
@@ -81,8 +81,9 @@
     [self.signinButton setAttributedTitle:attrstringFirstPart forState:UIControlStateNormal];
     
     NSString *arrowImageString = (kAppColorLight) ? @"arrow-light" : @"arrow-black";
-    [self.arrowImageView setImage:[UIImage imageNamed:arrowImageString]];
-    
+    [self.arrowImageView setImage:[[UIImage imageNamed:arrowImageString] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate]];
+    self.arrowImageView.tintColor = kCurrentAppColor;
+
     UITapGestureRecognizer * tapRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(viewTapped:)];
     [self.view addGestureRecognizer:tapRecognizer];
 }

--- a/Zype/ViewController/WatcherSignUpViewController.m
+++ b/Zype/ViewController/WatcherSignUpViewController.m
@@ -82,7 +82,7 @@
     
     NSString *arrowImageString = (kAppColorLight) ? @"arrow-light" : @"arrow-black";
     [self.arrowImageView setImage:[[UIImage imageNamed:arrowImageString] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate]];
-    self.arrowImageView.tintColor = kCurrentAppColor;
+    self.arrowImageView.tintColor = kClientColor;
 
     UITapGestureRecognizer * tapRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(viewTapped:)];
     [self.view addGestureRecognizer:tapRecognizer];


### PR DESCRIPTION
Merged 3 fixes - 
1. Arrow image color fixes on sign-in/sign-up screens
2. "Now" text removed 
3. Summary/Options tab brand color fixes.