### PR TITLE
Fix for iPad iOS 13.x issue with subscription plans

### DIFF
--- a/Zype/ViewController/SubsciptionViewController.m
+++ b/Zype/ViewController/SubsciptionViewController.m
@@ -54,6 +54,9 @@
 - (void)configureController {
     [self customizeAppearance];
     
+    //weird behavior with UITableViewComponent properties on iPad iOS13.x versions if table component is used as child control inside custom Scrollview. Need to explicitly set hidden No otherwise it's hidden automatically on iPad iOS 13.x.
+    [self.tableView setHidden:NO];
+    
     self.tableView.delegate = self;
     self.tableView.dataSource = self;
     [self.tableView registerNib:[UINib nibWithNibName:@"SubscriptActiveCell" bundle:nil] forCellReuseIdentifier:@"SubscriptActiveCell"];


### PR DESCRIPTION
It was weird behavior with UITableViewComponent properties on iPad iOS13.x versions if table component is used as child control inside custom Scrollview, it becomes hidden on screen launch. Fixed this issue with no side effect on iPhone devices. Please verify the fix for both iPhone and iPad devices.

