### PR TITLE
APPS-1307: Remove Platform Defined Darkmode Elements

### DIFF
--- a/Zype/AppDelegate.m
+++ b/Zype/AppDelegate.m
@@ -386,20 +386,16 @@
     
     //status bar can be configured here or disabled here and configured in info.plist
     if (kAppColorLight){
-        [[UIApplication sharedApplication] setStatusBarStyle:UIStatusBarStyleDefault];
-        
         //reset the deselected tab bar item color due to bug when setting UIView tint color
-        [[UIView appearanceWhenContainedIn:[UITabBar class], nil] setTintColor:[UIColor darkGrayColor]];//color for inactive item
+        [[UIView appearanceWhenContainedInInstancesOfClasses:@[[UITabBar class]]] setTintColor:[UIColor darkGrayColor]]; //color for inactive item
         [UITabBar appearance].tintColor = [UIColor darkTextColor];//[UIColor ZypeMainTintColor];//color for active item
         [UITabBar appearance].barTintColor = [UIColor whiteColor];
         
         [UITabBar appearance].backgroundColor = [UIColor whiteColor];
     }
     else {
-        [[UIApplication sharedApplication] setStatusBarStyle:UIStatusBarStyleLightContent];
-        
         //reset the deselected tab bar item color due to bug when setting UIView tint color
-        [[UIView appearanceWhenContainedIn:[UITabBar class], nil] setTintColor:[UIColor lightGrayColor]];//color for inactive item
+        [[UIView appearanceWhenContainedInInstancesOfClasses:@[[UITabBar class]]] setTintColor:[UIColor lightGrayColor]]; //color for inactive item
         [UITabBar appearance].tintColor = [UIColor whiteColor];//[UIColor ZypeMainTintColor];//color for active item
         [UITabBar appearance].barTintColor = [UIColor blackColor];
         

--- a/Zype/Info.plist
+++ b/Zype/Info.plist
@@ -75,17 +75,15 @@
 	<key>UIFileSharingEnabled</key>
 	<false/>
 	<key>UILaunchStoryboardName</key>
-    <string>LaunchScreen~iphone</string>
-    <key>UILaunchStoryboardName~ipad</key>
-    <string>LaunchScreen~ipad</string>
+	<string>LaunchScreen~iphone</string>
+	<key>UILaunchStoryboardName~ipad</key>
+	<string>LaunchScreen~ipad</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>
 	</array>
-	<key>UIStatusBarStyle</key>
-	<string>UIStatusBarStyleDefault</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
@@ -100,6 +98,10 @@
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
-	<false/>
+	<true/>
+	<key>UIStatusBarStyle</key>
+	<string>UIStatusBarStyleLightContent</string>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 </dict>
 </plist>


### PR DESCRIPTION
Brief - Made Zype theme independent of device theme.
JIRA - https://zypeinc.atlassian.net/browse/APPS-1307

Success Criteria
• The light mode iOS app template appears consistently whether the device is in night mode or day mode
• The dark mode iOS app template appears consistently whether the device is in night mode or day mode
